### PR TITLE
chore: change label removal logic

### DIFF
--- a/src/webhooks/closed.js
+++ b/src/webhooks/closed.js
@@ -8,11 +8,9 @@ const mergedPRs = fs.readFileSync(
     path.join(import.meta.dirname, '../message/merged.md'),
     'utf8'
 );
-const unremovableLabels = [
-    'maintainer',
-    'ci: bypass-owner-check',
-    'no-stale',
-    'r: william',
+const removableLabelPrefixes = [
+    'status:',
+    'reason:',
 ];
 const reviewerUsernames = [
     'DEV-DIBSTER',
@@ -78,15 +76,15 @@ export async function closed(
             }
         }
 
-        for (let i in listOfLabels) {
-            if (!unremovableLabels.includes(listOfLabels[i])) {
+        for (const label of listOfLabels) {
+            if (removableLabelPrefixes.some(prefix => label.startsWith(prefix))) {
                 await appOctokit.request(
                     'DELETE /repos/{owner}/{repo}/issues/{issue_number}/labels/{name}',
                     {
                         owner: repoOwner,
                         repo: repoName,
                         issue_number: prNumber,
-                        name: listOfLabels[i],
+                        name: label,
                     }
                 );
             }


### PR DESCRIPTION
rather than maintaining a list of "safe" labels we already know we want to remove `reason:` `status:` etc etc

this also fixes github-default labels like `ci` getting removed